### PR TITLE
ipfs: add infura ipfs api key

### DIFF
--- a/components/CreateStreamDialog.tsx
+++ b/components/CreateStreamDialog.tsx
@@ -175,7 +175,8 @@ const CreateStreamDialog = ({
 
   const { signTypedDataAsync } = useSignTypedData();
 
-  const onSubmitMetadata = async () => {
+  const onSubmitMetadata = async (e) => {
+    e.preventDefault();
     if (isGenerating || !account.data?.address) {
       return;
     }

--- a/pages/api/asset/create.ts
+++ b/pages/api/asset/create.ts
@@ -109,6 +109,12 @@ const requestHandler = async (
   if (req.method === "POST") {
     const body = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
     const ipfsHash = body.hash;
+    const INFURA_IPFS_ID = process.env.INFURA_IPFS_ID;
+    const INFURA_IPFS_SECRET = process.env.INFURA_IPFS_SECRET;
+
+    if (!INFURA_IPFS_ID || !INFURA_IPFS_SECRET) {
+      throw new Error("Missing INFURA_IPFS_ID and INFURA_IPFS_SECRET");
+    }
 
     if (!ipfsHash) {
       return res.status(500).json({ error: `Bad IPFS hash.` });
@@ -118,6 +124,10 @@ const requestHandler = async (
       `https://ipfs.infura.io:5001/api/v0/cat?arg=${ipfsHash}`,
       {
         method: "POST",
+        headers: {
+          Authorization:
+            "Basic " + btoa(INFURA_IPFS_ID + ":" + INFURA_IPFS_SECRET),
+        },
       }
     );
 

--- a/pages/api/upload-metadata.ts
+++ b/pages/api/upload-metadata.ts
@@ -21,6 +21,13 @@ const requestHandler = async (
   if (req.method === "POST") {
     const body = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
 
+    const INFURA_IPFS_ID = process.env.INFURA_IPFS_ID;
+    const INFURA_IPFS_SECRET = process.env.INFURA_IPFS_SECRET;
+
+    if (!INFURA_IPFS_ID || !INFURA_IPFS_SECRET) {
+      throw new Error("Missing INFURA_IPFS_ID and INFURA_IPFS_SECRET");
+    }
+
     const formData = new FormData();
 
     formData.append("file", JSON.stringify(body));
@@ -30,6 +37,10 @@ const requestHandler = async (
       {
         method: "POST",
         body: formData,
+        headers: {
+          Authorization:
+            "Basic " + btoa(INFURA_IPFS_ID + ":" + INFURA_IPFS_SECRET),
+        },
       }
     );
 


### PR DESCRIPTION
Previous example was giving a 401; this seems to fix things. Also added an `e.preventDefault()` where it was apparently causing problems.