### PR TITLE
docs: replace temporary Discord invite URL with permanent URL

### DIFF
--- a/components/Drawer/index.tsx
+++ b/components/Drawer/index.tsx
@@ -137,7 +137,7 @@ const Index = ({ items = [], open, onDrawerOpen, onDrawerClose }) => {
               
               <A
                 css={{ fontSize: "$2", mb: "$2", display: "block" }}
-                href="https://discord.gg/uaPhtyrWsF"
+                href="https://discord.gg/livepeer"
                 target="_blank"
                 rel="noopener noreferrer"
               >


### PR DESCRIPTION
This pull request updates the Discord invite URL from a temporary (expiring)
link to a fixed (permanent) one to ensure long-term accessibility.
